### PR TITLE
Add support for arm64 installation

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -40,7 +40,15 @@ get_platform() {
 }
 
 get_arch() {
-  [[ "x86_64" == "$(uname -m)" ]] && echo "amd64" || echo "i386"
+  local arch=$(uname -m)
+  if [ $arch == "x86_64" ]; then
+    arch="amd64"
+  elif [ $arch == "arm64" ]; then
+    arch="arm64"
+  else
+    arch="386"
+  fi
+  echo $arch
 }
 
 get_download_url() {


### PR DESCRIPTION
Phrase releases currently support installations for M1 macs, however due to the way the install command works for the asdf plugin, this is not currently possible. Want to add support for installing for M1 macs via the asdf plugin.